### PR TITLE
Firefox forbids setting Content-Length

### DIFF
--- a/src/main/webapp/js/diagramly/OneDriveClient.js
+++ b/src/main/webapp/js/diagramly/OneDriveClient.js
@@ -949,7 +949,6 @@ OneDriveClient.prototype.writeLargeFile = function(url, data, success, error, et
 						
 					req.setRequestHeaders = mxUtils.bind(this, function(request, params)
 					{
-						request.setRequestHeader('Content-Length', part.length);
 						request.setRequestHeader('Content-Range', 'bytes ' + index + '-' + (index + part.length - 1) + '/' + data.length);
 					});
 


### PR DESCRIPTION
When saving large file to OneDrive, Firefox prevents from storing that file.

Because: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name

![image](https://user-images.githubusercontent.com/1453957/93687631-c2b06f00-fac7-11ea-856b-758c3320c784.png)
![image](https://user-images.githubusercontent.com/1453957/93687635-c93ee680-fac7-11ea-895a-4af1615039be.png)

:information_source: Have not tested locally.